### PR TITLE
Add mock display for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .idea
 **.pyc
+
+# image storage when running locally
+src/img.png

--- a/readme.md
+++ b/readme.md
@@ -19,9 +19,9 @@ add the Waveshare SDK to your path (see [Dockerfile](./Dockerfile)).
 on a webserver with more than a single worker, should you choose to use a webserver other than the Flask development
 webserver.
 
-## How to use
+## Setup
 
-### Install
+### Install on a Raspberry Pi + Display
 
 Build and run the container:
 
@@ -34,6 +34,17 @@ docker run -p 5000:5000 --restart=always --privileged rpi-eink-api
 Now you're ready to send images to the display!
 
 `--restart=always` will ensure that the container is restarted on crash and on system boot. 
+
+### Running locally
+
+You can run also run the API locally using the `EPD_MOCK=true` env var to mock all calls to the display itself.
+You can still check that the correct image is produced by looking at `src/img.png`.
+
+```commandline
+EPD_MOCK=true python3 src/server.py
+```
+
+## API
 
 ### Setting the image
 

--- a/src/epd_utils.py
+++ b/src/epd_utils.py
@@ -6,9 +6,12 @@ from flask import Response, jsonify
 
 from models import Mode
 
-path.append('lib')
-# noinspection PyUnresolvedReferences
-from waveshare_epd import epd4in26
+try:
+    path.append('lib')
+    # noinspection PyUnresolvedReferences
+    from waveshare_epd import epd4in26
+except Exception as e:
+    logging.warning('could not import wavesare lib')
 
 
 def get_epd():

--- a/src/server.py
+++ b/src/server.py
@@ -1,5 +1,7 @@
 import json
+import os
 from pathlib import Path
+from unittest.mock import Mock
 
 from flask import Flask, request, jsonify, send_file, Response
 
@@ -13,7 +15,6 @@ from models import Resolution, Rotation, Resize, BackgroundColour, Mode
 from img_utils import resize_img, image_changed
 from epd_utils import handle_epd_error, display_clear, display_img, get_epd
 
-
 IMG_PATH = 'img.png'
 DISPLAY_RESOLUTION = Resolution(800, 480)
 
@@ -21,7 +22,16 @@ logging.basicConfig(level=logging.DEBUG)
 
 register_heif_opener()
 
-epd = get_epd()
+
+def str_is_true(value) -> bool:
+    return value in [True, 'true', '1']
+
+
+def mock_epd() -> bool:
+    return str_is_true(os.getenv('EPD_MOCK'))
+
+
+epd = get_epd() if mock_epd() is False else Mock()
 
 app = Flask(__name__)
 
@@ -70,7 +80,7 @@ def show_image() -> tuple[Response, int]:
     except ValueError:
         return jsonify(message=f'"mode" invalid, must be one of {", ".join([x for x in Mode])}'), 422
 
-    dither = request.form.get('dither', 'true') in ['true', '1']
+    dither = str_is_true(request.form.get('dither', True))
 
     loc = locals()
     image_settings = {i: loc[i] for i in ('mode', 'dither', 'rotate', 'resize', 'background')}
@@ -104,3 +114,6 @@ def clear_image():
         return jsonify(message='Success'), 200
     except Exception as e:
         return handle_epd_error(e)
+
+if __name__ == "__main__":
+    app.run(port=5000)


### PR DESCRIPTION
As it says on the tin. An env var can be set to replace the real epd object (which handles all interactions with the display) with `Mock()` from `unittest`, which simply ignores all calls.